### PR TITLE
issue 1-2

### DIFF
--- a/bin/fdp-run
+++ b/bin/fdp-run
@@ -2,16 +2,19 @@
 """FDP run.
 
 Usage:
-  fdp-run <data-file>
+  fdp-run --data <data-file>
+  fdp-run --sparql <sparql-endpoint>
   fdp-run (-h | --help)
 
 Options:
   -h --help     Show this screen.
-  <data-file>   ini or ttl file containing FDP data
+  --data <data-file>   ini or ttl file containing FDP data
+  --sparql <sparql-endpoint>  sparql endpoint URL
 """
 from docopt import docopt
 from fdp import __version__
 from fdp.fdp import run_app
 
 args = docopt(__doc__, version='FDP run ' + __version__)
-run_app(host='0.0.0.0', port=8080, dataFile=args['<data-file>'])
+run_app(host='0.0.0.0', port=8080, dataFile=args['--data'],
+        endpoint=args['--sparql'])

--- a/fdp/fdp.py
+++ b/fdp/fdp.py
@@ -57,10 +57,24 @@ def httpResponse(graph, uri):
         fmt = mime_types[accept_header]
 
     serialized_graph = graph.serialize(uri, fmt)
-    resp = make_response(serialized_graph)
-
     if serialized_graph is None:
-        return 'Web resource not found', 404
+        resp = make_response({'message': 'Not Found'}, 404)
+    else:
+        resp = make_response(serialized_graph)
+        resp.headers['Content-Type'] = 'text/plain'
+        resp.headers['Allow'] = 'GET'
+
+    return resp
+
+def httpResponceNav(graph, layer):
+    """HTTP response: metadata navigations"""
+
+    s = graph.navURI(layer)
+
+    if s:
+        resp = make_response('\n'.join(s), 200)
+    else:
+        resp = make_response({'message': 'No Content'}, 204)
 
     resp.headers['Content-Type'] = 'text/plain'
     resp.headers['Allow'] = 'GET'
@@ -78,8 +92,11 @@ def defaultPage():
 def sourceDocFiles(fname):
     return send_from_directory('doc', fname)
 
-@ns.route('fdp/')
+@ns.route('fdp')
 class FDPResource(Resource):
+    model = api.parser()
+    model.add_argument('text', type=str, location='json')
+
     def get(self):
         '''
         FDP metadata
@@ -87,14 +104,33 @@ class FDPResource(Resource):
         graph = data['graph']
         return httpResponse(graph, graph.fdpURI())
 
-    def patch(self):
+    @api.expect(model)
+    def post(self):
         '''
-        Update fdp metadata
+        Create new FDP metadata
         '''
-        return '', 500
+        req_data = request.data
+        req_data = req_data.decode('utf-8')
+        valid, message = validator.validateFDP(req_data)
+        # TODO validate to make sure there is only one subject
+        graph = data['graph']
+        if valid:
+            graph.post(data=req_data, format='turtle')
+            return make_response({'message': 'OK'}, 200)
+        else:
+            return make_response({'message': message}, 500)
+
+    def delete(self):
+        '''
+        Delete FDP metadata
+        '''
+        return make_response({'message': 'Method Not Allowed'}, 405)
 
 @ns.route('catalog/<id>')
 class CatalogGetterResource(Resource):
+    model = api.parser()
+    model.add_argument('text', type=str, location='json')
+
     def get(self, id):
         '''
         Catalog metadata
@@ -102,10 +138,43 @@ class CatalogGetterResource(Resource):
         graph = data['graph']
         return httpResponse(graph, graph.catURI(id))
 
+    @api.expect(model)
+    def post(self, id):
+        '''
+        POST catalog metadata
+        '''
+        req_data = request.data
+        req_data = req_data.decode('utf-8')
+        valid, message = validator.validateCatalog(req_data)
+        # TODO validate to make sure there is only one subject
+        graph = data['graph']
+        if valid:
+            graph.post(data=req_data, format='turtle')
+            return make_response({'message': 'OK'}, 200)
+        else:
+            return make_response({'message': message}, 500)
+
+    def delete(self, id):
+        '''
+        Delete the catalog ID and metadata
+        '''
+        graph = data['graph']
+        if not graph.URIexists(graph.catURI(id)):
+            return make_response({'message': 'Not Found'}, 404)
+        graph.deleteURI(graph.catURI(id))
+        return make_response({'message': 'OK'}, 200)
+
 @ns.route('catalog/')
 class CatalogPostResource(Resource):
     model = api.parser()
     model.add_argument('text', type=str, location='json')
+
+    def get(self):
+        '''
+        Get the list of catalog URIs
+        '''
+        graph = data['graph']
+        return httpResponceNav(graph, 'Catalog')
 
     @api.expect(model)
     def post(self):
@@ -114,16 +183,24 @@ class CatalogPostResource(Resource):
         '''
         req_data = request.data
         req_data = req_data.decode('utf-8')
-
         valid, message = validator.validateCatalog(req_data)
+        graph = data['graph']
         if valid:
-            data['graph'].addCatURI(data=req_data, format='turtle')
+            data['graph'].post(data=req_data, format='turtle')
             return make_response({'message': 'Ok'}, 200)
         else:
             return make_response({'message': message}, 500)
 
+    def delete(self):
+        """Delete all catalog metadata"""
+        graph = data['graph']
+        graph.deleteURILayer('Catalog')
+        return make_response({'message': 'OK'}, 200)
+
 @ns.route('dataset/<id>')
 class DatasetMetadataGetterResource(Resource):
+    model = api.parser()
+    model.add_argument('text', type=str, location='json')
     def get(self, id):
         '''
         Dataset metadata
@@ -131,11 +208,43 @@ class DatasetMetadataGetterResource(Resource):
         graph = data['graph']
         return httpResponse(graph, graph.datURI(id))
 
+    @api.expect(model)
+    def post(self, id):
+        '''
+        POST dataset metadata
+        '''
+        req_data = request.data
+        req_data = req_data.decode('utf-8')
+        valid, message = validator.validateDataset(req_data)
+        # TODO validate to make sure there is only one subject
+        graph = data['graph']
+        if valid:
+            graph.post(data=req_data, format='turtle')
+            return make_response({'message': 'OK'}, 200)
+        else:
+            return make_response({'message': message}, 500)
+
+    def delete(self, id):
+        '''
+        Delete the dataset ID and metadata
+        '''
+        graph = data['graph']
+        if not graph.URIexists(graph.datURI(id)):
+            return make_response({'message': 'Not Found'}, 404)
+        graph.deleteURI(graph.datURI(id))
+        return make_response({'message': 'OK'}, 200)
 
 @ns.route('dataset/')
 class DatasetMetadataPostResource(Resource):
     model = api.parser()
     model.add_argument('text', type=str, location='json')
+
+    def get(self):
+        '''
+        Get the list of dataset URIs
+        '''
+        graph = data['graph']
+        return httpResponceNav(graph, 'Dataset')
 
     @api.expect(model)
     def post(self):
@@ -144,17 +253,23 @@ class DatasetMetadataPostResource(Resource):
         '''
         req_data = request.data
         req_data = req_data.decode('utf-8')
-
         valid, message = validator.validateDataset(req_data)
         if valid:
-            data['graph']._graph.parse(data=req_data, format='turtle')
+            data['graph'].post(data=req_data, format='turtle')
             return make_response({'message': 'Ok'}, 200)
         else:
             return make_response({'message': message}, 500)
 
+    def delete(self):
+        """Delete all dataset metadata"""
+        graph = data['graph']
+        graph.deleteURILayer('Dataset')
+        return make_response({'message': 'OK'}, 200)
 
 @ns.route('distribution/<id>')
 class DistributionGetterResource(Resource):
+    model = api.parser()
+    model.add_argument('text', type=str, location='json')
     def get(self, id):
         '''
         Dataset distribution metadata
@@ -162,10 +277,43 @@ class DistributionGetterResource(Resource):
         graph = data['graph']
         return httpResponse(graph, graph.distURI(id))
 
+    @api.expect(model)
+    def post(self, id):
+        '''
+        POST distribution metadata
+        '''
+        req_data = request.data
+        req_data = req_data.decode('utf-8')
+        # TODO validate to make sure there is only one subject
+        valid, message = validator.validateDistribution(req_data)
+        graph = data['graph']
+        if valid:
+            graph.post(data=req_data, format='turtle')
+            return make_response({'message': 'OK'}, 200)
+        else:
+            return make_response({'message': message}, 500)
+
+    def delete(self, id):
+        '''
+        Delete the distribution ID and metadata
+        '''
+        graph = data['graph']
+        if not graph.URIexists(graph.distURI(id)):
+            return make_response({'message': 'Not Found'}, 404)
+        graph.deleteURI(graph.distURI(id))
+        return make_response({'message': 'OK'}, 200)
+
 @ns.route('distribution/')
 class DistributionPostResource(Resource):
     model = api.parser()
     model.add_argument('text', type=str, location='json')
+
+    def get(self):
+        '''
+        Get the list of distribution URIs
+        '''
+        graph = data['graph']
+        return httpResponceNav(graph, 'Distribution')
 
     @api.expect(model)
     def post(self):
@@ -177,11 +325,16 @@ class DistributionPostResource(Resource):
 
         valid, message = validator.validateDistribution(req_data)
         if valid:
-            data['graph']._graph.parse(data=req_data, format='turtle')
+            data['graph'].post(data=req_data, format='turtle')
             return make_response({'message': 'Ok'}, 200)
         else:
             return make_response({'message': message}, 500)
 
+    def delete(self):
+        """Delete all distribution metadata"""
+        graph = data['graph']
+        graph.deleteURILayer('Distribution')
+        return make_response({'message': 'OK'}, 200)
 
 @ns.route('dump/')
 class DumpResource(Resource):

--- a/fdp/schema/fdp.shacl
+++ b/fdp/schema/fdp.shacl
@@ -1,0 +1,47 @@
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdp: <http://rdf.biosemantics.org/ontologies/fdp-o#> .
+@prefix r3d: <http://www.re3data.org/schema/3-0> .
+
+schema:DatasetShape
+    a sh:NodeShape ;
+    sh:targetClass r3d:Repository;
+    sh:property [
+        sh:name "FDP title" ;
+        sh:path dct:title ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:name "FDP version" ;
+        sh:path dct:hasVersion ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:name "FDP publisher" ;
+        sh:path dct:publisher ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:name "FDP relation to the parent metadata" ;
+        sh:path dct:isPartOf ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:name "FDP metadata identifier" ;
+        sh:path fdp:metadataIdentifier ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:name "FDP metadata issued date" ;
+        sh:path fdp:metadataIssued ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:name "FDP metadata modified date" ;
+        sh:path fdp:metadataModified ;
+        sh:minCount 1 ;
+    ] .

--- a/fdp/storegraph.py
+++ b/fdp/storegraph.py
@@ -1,14 +1,16 @@
 from rdflib import ConjunctiveGraph, Graph
+from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
 from rdflib.term import URIRef
 
 API_ENDPOINTS = {'/fdp', '/doc', '/catalog', '/dataset', '/distribution'}
 
-class FAIRGraph(object):
-    def __init__(self, base_uri, ttl_file):
-        # UPGRADE: use rdflib.plugins.stores.sparqlstore.SPARQLStore
-        # for SPARQL backend.
-        self._graph = ConjunctiveGraph()
-        self._graph.parse(ttl_file, format="n3")
+
+class StoreFAIRGraph(object):
+    def __init__(self, base_uri, endpoint):
+        default_graph = URIRef(base_uri)
+
+        self._store = SPARQLUpdateStore(endpoint)
+        self._graph = Graph(self._store, identifier=default_graph)
         self._base_uri = base_uri
 
     def _buildURI(self, endpoint, id=None):
@@ -23,7 +25,12 @@ class FAIRGraph(object):
         return self._buildURI('/catalog', id)
 
     def addCatURI(self, data, format):
-        self._graph.parse(data=data, format=format)
+        # Load data on the graph
+        g = ConjunctiveGraph()
+        g.parse(data=data, format=format)
+        for s, p, o in g:
+            self._graph.add((s, p, o))
+        self._graph.commit()
 
     def datURI(self, id):
         return self._buildURI('/dataset', id)
@@ -34,14 +41,14 @@ class FAIRGraph(object):
     def serialize(self, uri, mime_type):
         g = Graph()
         # Copy namespaces from base graph
-        for prefix,ns_uri in self._graph.namespaces():
+        for prefix, ns_uri in self._graph.namespaces():
             g.bind(prefix, ns_uri)
 
         # Search for triples which match the given subject
         matchPattern = (URIRef(uri), None, None)
-        g += self._graph.triples( matchPattern )
+        g += self._graph.triples(matchPattern)
 
         if len(g.all_nodes()) > 0:
             return g.serialize(format='turtle').decode('utf-8')
         else:
-            return None # 404 !
+            return None  # 404 !

--- a/fdp/validator.py
+++ b/fdp/validator.py
@@ -21,6 +21,9 @@ def _validate(data_file, shapes_file):
 
 class FDPValidator():
     def __init__(self):
+        # TODO udpate the shacl files according to FDP spec
+        print('Loading fdp shapes')
+        self.fdp_shapes = pkg_resources.resource_string(__name__, 'schema/fdp.shacl')
         print('Loading catalog shapes')
         self.catalog_shapes = pkg_resources.resource_string(__name__, 'schema/catalog.shacl')
         print('Loading dataset shapes')
@@ -28,11 +31,14 @@ class FDPValidator():
         print('Loading distribution shapes')
         self.distribution_shapes = pkg_resources.resource_string(__name__, 'schema/distribution.shacl')
 
-    def validateCatalog(self, cat_data):
-        return _validate(cat_data, self.catalog_shapes)
+    def validateFDP(self, data):
+        return _validate(data, self.fdp_shapes)
 
-    def validateDataset(self, cat_data):
-        return _validate(cat_data, self.dataset_shapes)
+    def validateCatalog(self, data):
+        return _validate(data, self.catalog_shapes)
 
-    def validateDistribution(self, cat_data):
-        return _validate(cat_data, self.distribution_shapes)
+    def validateDataset(self, data):
+        return _validate(data, self.dataset_shapes)
+
+    def validateDistribution(self, data):
+        return _validate(data, self.distribution_shapes)


### PR DESCRIPTION
To solve issue #1 #2 .

The FDP spec requires that the metadata of each layer (fdp, catalog, dataset or distribution) must contain some mandatory terms. Because of this, it seems more reasonable to treat a list of mandatory terms (and optional terms) as the minimal input unit, but not treat a triple (SPO) as the minimal input unit. Based on this idea, the http method POST seems enough to create, append, replace and modify resource. So the http methods are implemented as following:

|              |       GET      |                                             POST                                             |     DELETE     |
|--------------|:--------------:|:--------------------------------------------------------------------------------------------:|:--------------:|
| fdp          | Output triples | Remove existing triples for a specific ID, <br>then create new triples with the request data | Not Allowed    |
| catalog/     | Out all IDs    | same as above                                                                                | Remove all IDs |
| catalog/\<id\> | Output triples | same as above                                                                                | Remove the ID  |


How to test the code currently:
1. `docker run --rm --name virtuoso -e SPARQL_UPDATE=true -d -p 1111:1111 -p 8890:8890 tenforce/virtuoso`
2. `fdp-run --sparql http://0.0.0.0:8890/sparql`
3.  run the commands given in the file [sample.zip](https://github.com/c-martinez/FAIRDataPoint/files/4529813/sample.zip)

